### PR TITLE
feat: add notification settings panel and service

### DIFF
--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -5,32 +5,30 @@ import { Switch } from '../components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import { AppBar } from '../components/AppShell';
 import { useAppShell } from '../components/AppShell';
-import { useNotifications } from '../providers/notificationProvider';
+import { useNotificationsStore } from '../store/NotificationsStore';
 import seventhPathLogo from '../assets/d39dcef0d5c4765688b970ab66912bbb65f81e62.png';
-import { useHabitStore } from '../lib/habitStore';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../components/ui/dialog';
-import { LocalNotifications } from '@capacitor/local-notifications';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - vite json import allowed
 import pkg from '../../package.json';
 
 export function Settings() {
   const { userName, theme, setTheme, setIsOnboarded, navigate } = useAppShell();
-  const { 
-    isPermissionGranted, 
-    requestPermission, 
-    sendTestNotification, 
-    isLoading: notificationLoading,
-    error: notificationError,
-    isEnabled,
+  const {
+    permission,
+    enabled,
+    scheduledCount,
+    hydrate,
+    requestPermission,
     setEnabled,
-  } = useNotifications();
-  const { clearAllHabits } = useHabitStore();
-  
+    refreshScheduledCount,
+    sendTest,
+    openSystemSettings,
+  } = useNotificationsStore();
+
   const [isTestingNotification, setIsTestingNotification] = useState(false);
   const [aboutOpen, setAboutOpen] = useState(false);
   const version = useMemo(() => (pkg?.version as string) || '1.0.0', []);
-  const [pendingCount, setPendingCount] = useState<number>(0);
 
   const openLink = useCallback(async (url: string) => {
     try {
@@ -66,14 +64,8 @@ export function Settings() {
   const handleTestNotification = async () => {
     try {
       setIsTestingNotification(true);
-      await sendTestNotification(
-        '🔔 Test Notification',
-        'This is a test notification from Seventh Path!'
-      );
-      try {
-        const pending = await LocalNotifications.getPending();
-        setPendingCount(pending.notifications.length);
-      } catch {}
+      await sendTest();
+      await refreshScheduledCount();
     } catch (error) {
       console.error('Error sending test notification:', error);
     } finally {
@@ -82,13 +74,8 @@ export function Settings() {
   };
 
   React.useEffect(() => {
-    (async () => {
-      try {
-        const pending = await LocalNotifications.getPending();
-        setPendingCount(pending.notifications.length);
-      } catch {}
-    })();
-  }, []);
+    hydrate();
+  }, [hydrate]);
 
   const SettingsSection = ({ title, children }: { title: string; children: React.ReactNode }) => (
     <div className="mb-6">
@@ -167,27 +154,27 @@ export function Settings() {
           <SettingsRow
             icon={<Bell size={20} />}
             title="Notifications"
-            description={isPermissionGranted ? 'Permission granted' : 'Permission required'}
+            description={`Permission: ${permission}`}
             action={
-              <Switch
-                checked={isPermissionGranted}
-                onCheckedChange={handleRequestNotificationPermission}
-                disabled={notificationLoading}
-              />
+              permission === 'granted' ? (
+                <Button size="sm" variant="outline" onClick={openSystemSettings}>System</Button>
+              ) : (
+                <Button size="sm" variant="outline" onClick={handleRequestNotificationPermission}>Enable</Button>
+              )
             }
           />
 
           <SettingsRow
             icon={<SettingsIcon size={20} />}
             title="Enabled"
-            description={isPermissionGranted ? 'App will send notifications' : 'Grant permission to enable'}
+            description={permission === 'granted' ? 'App notifications' : 'Grant permission first'}
             action={
               <Switch
-                checked={isEnabled}
+                checked={enabled}
                 onCheckedChange={async (on) => {
                   try { await setEnabled(on); } catch (e) { console.error(e); }
                 }}
-                disabled={notificationLoading || !isPermissionGranted}
+                disabled={permission !== 'granted'}
               />
             }
           />
@@ -195,43 +182,28 @@ export function Settings() {
           <SettingsRow
             icon={<TestTube size={20} />}
             title="Scheduled Count"
-            description={`${pendingCount} scheduled`}
+            description={`${scheduledCount} scheduled`}
             action={
-              <Button size="sm" variant="outline" onClick={async () => {
-                try { const p = await LocalNotifications.getPending(); setPendingCount(p.notifications.length); } catch {}
-              }}>Refresh</Button>
+              <Button size="sm" variant="outline" onClick={refreshScheduledCount}>Refresh</Button>
             }
           />
 
           <SettingsRow
             icon={<TestTube size={20} />}
             title="Test Notification"
-            description={isPermissionGranted ? "Send a test notification to verify it's working" : 'Grant permission first'}
+            description={permission === 'granted' ? "Send a test notification" : 'Grant permission first'}
             action={
               <Button
                 size="sm"
                 variant="outline"
                 onClick={handleTestNotification}
-                disabled={isTestingNotification || !isPermissionGranted || !isEnabled}
+                disabled={isTestingNotification || permission !== 'granted' || !enabled}
               >
                 {isTestingNotification ? 'Sending...' : 'Test'}
               </Button>
             }
           />
         </SettingsSection>
-
-        {/* Error Display */}
-        {notificationError && (
-          <SettingsSection title="Error">
-            <div className="p-4 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg">
-              <div className="flex items-center gap-2 mb-2">
-                <Bell size={16} className="text-red-600 dark:text-red-400" />
-                <h3 className="font-medium text-red-900 dark:text-red-100">Notification Error</h3>
-              </div>
-              <p className="text-sm text-red-800 dark:text-red-200">{notificationError}</p>
-            </div>
-          </SettingsSection>
-        )}
 
         {/* Preferences Section */}
         <SettingsSection title="Preferences">

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,0 +1,81 @@
+import { Capacitor } from '@capacitor/core';
+import { LocalNotifications, type PermissionStatus, type ScheduleOptions, type PendingResult } from '@capacitor/local-notifications';
+import { App } from '@capacitor/app';
+
+// Helper to map PermissionStatus to spec types
+function mapPermission(status: PermissionStatus['display']): 'granted' | 'denied' | 'prompt' {
+  if (status === 'granted') return 'granted';
+  if (status === 'denied') return 'denied';
+  return 'prompt';
+}
+
+class NotificationService {
+  private async ensureChannels(): Promise<void> {
+    if (Capacitor.getPlatform() !== 'android') return;
+    try {
+      await LocalNotifications.createChannel({
+        id: 'seventhpath_default',
+        name: 'Default',
+        importance: 3, // IMPORTANCE_DEFAULT
+      });
+      await LocalNotifications.createChannel({
+        id: 'seventhpath_reminders',
+        name: 'Habit Reminders',
+        importance: 4, // IMPORTANCE_HIGH
+        sound: 'ting_positive',
+        vibration: true,
+      });
+    } catch {
+      // ignore
+    }
+  }
+
+  async checkPermission(): Promise<'granted' | 'denied' | 'prompt'> {
+    const res = await LocalNotifications.checkPermissions();
+    return mapPermission(res.display);
+  }
+
+  async requestPermission(): Promise<'granted' | 'denied' | 'prompt'> {
+    const res = await LocalNotifications.requestPermissions();
+    await this.ensureChannels();
+    return mapPermission(res.display);
+  }
+
+  async getPendingCount(): Promise<number> {
+    try {
+      const pending: PendingResult = await LocalNotifications.getPending();
+      return pending.notifications.length;
+    } catch {
+      return 0;
+    }
+  }
+
+  async sendTestNotification(): Promise<void> {
+    const id = Date.now();
+    const sound = Capacitor.getPlatform() === 'ios' ? 'ting_positive.mp3' : 'ting_positive';
+    const opts: ScheduleOptions = {
+      notifications: [
+        {
+          id,
+          title: 'Seventh Path',
+          body: 'Test notification',
+          schedule: { at: new Date(Date.now() + 1000) },
+          channelId: 'seventhpath_reminders',
+          sound,
+        },
+      ],
+    };
+    await LocalNotifications.schedule(opts);
+  }
+
+  async openSystemSettings(): Promise<void> {
+    try {
+      await App.openSettings();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export const notificationService = new NotificationService();
+export type PermissionState = 'granted' | 'denied' | 'prompt';

--- a/src/store/NotificationsStore.ts
+++ b/src/store/NotificationsStore.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+import { Capacitor } from '@capacitor/core';
+import { App } from '@capacitor/app';
+import { notificationService, type PermissionState } from '../services/NotificationService';
+
+// simple Preferences helpers
+async function setPref(key: string, value: string): Promise<void> {
+  const anyWin: any = globalThis as any;
+  const prefs = anyWin?.Capacitor?.Plugins?.Preferences;
+  if (prefs && Capacitor.getPlatform() !== 'web') {
+    await prefs.set({ key, value });
+  } else {
+    localStorage.setItem(key, value);
+  }
+}
+
+async function getPref(key: string): Promise<string | null> {
+  const anyWin: any = globalThis as any;
+  const prefs = anyWin?.Capacitor?.Plugins?.Preferences;
+  if (prefs && Capacitor.getPlatform() !== 'web') {
+    const res = await prefs.get({ key });
+    return res.value ?? null;
+  }
+  return localStorage.getItem(key);
+}
+
+const ENABLED_KEY = 'notifications:enabled';
+
+interface NotificationsState {
+  permission: PermissionState;
+  enabled: boolean;
+  scheduledCount: number;
+  hydrate: () => Promise<void>;
+  requestPermission: () => Promise<void>;
+  setEnabled: (on: boolean) => Promise<void>;
+  refreshScheduledCount: () => Promise<void>;
+  sendTest: () => Promise<void>;
+  openSystemSettings: () => Promise<void>;
+}
+
+export const useNotificationsStore = create<NotificationsState>()((set, get) => ({
+  permission: 'prompt',
+  enabled: true,
+  scheduledCount: 0,
+
+  hydrate: async () => {
+    const perm = await notificationService.checkPermission();
+    const enabledStr = await getPref(ENABLED_KEY);
+    const enabled = enabledStr !== 'false';
+    const count = await notificationService.getPendingCount();
+    set({ permission: perm, enabled, scheduledCount: count });
+  },
+
+  requestPermission: async () => {
+    const perm = await notificationService.requestPermission();
+    set({ permission: perm });
+    await get().refreshScheduledCount();
+  },
+
+  setEnabled: async (on: boolean) => {
+    set({ enabled: on });
+    await setPref(ENABLED_KEY, on ? 'true' : 'false');
+  },
+
+  refreshScheduledCount: async () => {
+    const count = await notificationService.getPendingCount();
+    set({ scheduledCount: count });
+  },
+
+  sendTest: async () => {
+    if (get().permission !== 'granted' || !get().enabled) return;
+    await notificationService.sendTestNotification();
+    await get().refreshScheduledCount();
+  },
+
+  openSystemSettings: async () => {
+    await notificationService.openSystemSettings();
+  },
+}));
+
+// Rehydrate on app resume
+App.addListener('appStateChange', ({ isActive }) => {
+  if (isActive) useNotificationsStore.getState().hydrate().catch(() => {});
+});


### PR DESCRIPTION
## Summary
- add NotificationService wrapping Capacitor Local Notifications with channel setup and test send
- introduce NotificationsStore for permission, enabled state and scheduled count
- update Settings screen with notification controls and test trigger

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c1a529fc8323972fb4b12ef57ee6